### PR TITLE
Replace Functionality to Get Username for Container Compatibility

### DIFF
--- a/src/interact.c
+++ b/src/interact.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <pwd.h>
 
 #include <readline/readline.h>
 #include <readline/history.h>
@@ -27,8 +28,8 @@ static void maybe_add_history(const char *string)
 
 static int get_user_name(char *user_buf, size_t size)
 {
-	struct passwd* = getpwuid(getuid());
-	memcpy(user_buf, passwd->pw_name, size);
+	struct passwd *pw = getpwuid(getuid());
+	strncat(user_buf, pw->pw_name, size);
 	return errno == 0 ? 0 : -1;
 }
 
@@ -36,7 +37,7 @@ static int get_user_name(char *user_buf, size_t size)
 
 char *default_prompt_generator(int last_return_code)
 {
-	char user_buf[256];
+	char user_buf[256] = { 0 };
 	char hostname_buf[256] = { 0 };
 	char cwd_buf[PATH_MAX];
 	const char *user = user_buf;

--- a/src/interact.c
+++ b/src/interact.c
@@ -25,6 +25,13 @@ static void maybe_add_history(const char *string)
 	add_history(string);
 }
 
+static int get_user_name(char *user_buf, size_t size)
+{
+	struct passwd* = getpwuid(getuid());
+	memcpy(user_buf, passwd->pw_name, size);
+	return errno == 0 ? 0 : -1;
+}
+
 #define PROMPT_FMT "%s@%s %s %s $ "
 
 char *default_prompt_generator(int last_return_code)
@@ -38,7 +45,7 @@ char *default_prompt_generator(int last_return_code)
 	char *prompt;
 	size_t prompt_sz;
 
-	if (getlogin_r(user_buf, sizeof(user_buf)) < 0) {
+	if (get_user_name(user_buf, sizeof(user_buf)) < 0) {
 		fprintf(stderr, "Unable to get current username: %s\n",
 			strerror(errno));
 		user = "???";


### PR DESCRIPTION
The current syscall used for getting the user name, getlogin_r (functionally equivalent to the 'who' command), does not work well with container images because there is no logged-in user (you can confirm this on the student-env containers with the 'w' command), which results in weird behavior, as no error is detected either, so some garbage characters get fed to print which is visually unappealing and potentially problematic. The container will still set a real and effective uid, however, so we can still work out the username with the getpwuid syscall (functionally equivalent to the 'whoami' command). This implementation is not quite functionally equivalent to the original, but it is very close, and the edge cases where the functionality differs don't seem to be relevant to the assignment. This change was designed to make minimal changes to the code structure, and the fix has been confirmed to work on the student-env containers. Let me know if you have any questions or suggestions for my pull. Thanks!